### PR TITLE
Fix IntPoint's equality operator not considering Z

### DIFF
--- a/clipper/clipper.hpp
+++ b/clipper/clipper.hpp
@@ -96,11 +96,19 @@ struct IntPoint {
 
   friend inline bool operator== (const IntPoint& a, const IntPoint& b)
   {
+#ifdef use_xyz
+    return a.X == b.X && a.Y == b.Y && a.Z == b.Z;
+#else
     return a.X == b.X && a.Y == b.Y;
+#endif
   }
   friend inline bool operator!= (const IntPoint& a, const IntPoint& b)
   {
-    return a.X != b.X  || a.Y != b.Y; 
+#ifdef use_xyz
+    return a.X != b.X  || a.Y != b.Y || a.Z != b.Z;
+#else
+    return a.X != b.X  || a.Y != b.Y;
+#endif
   }
 };
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Hi,

IntPoint's == operator does not compare Z values.

This might have stayed under the radar up to now because == is mostly used when adding paths, to check for redundancies, and it should not misbehave in a noticeable way when dealing with long complex paths.

In my case, I merged triangles and Clipper stripped the last vertex of each path (was considered equal to another vertex from the path because of the bug). Then Clipper failed because the closed paths had less than 3 vertices.